### PR TITLE
feat: animate rolls

### DIFF
--- a/app/javascript/controllers/appear_controller.js
+++ b/app/javascript/controllers/appear_controller.js
@@ -1,0 +1,13 @@
+import { Controller } from "@hotwired/stimulus";
+import { enter } from "el-transition";
+
+/**
+ * This controller animates an element in once connected to the DOM.
+ * See https://github.com/mmccall10/el-transition for configuration options.
+ */
+export default class extends Controller {
+  connect() {
+    this.element.classList.remove("hidden");
+    enter(this.element);
+  }
+}

--- a/app/javascript/controllers/hello_controller.js
+++ b/app/javascript/controllers/hello_controller.js
@@ -1,7 +1,0 @@
-import { Controller } from "@hotwired/stimulus"
-
-export default class extends Controller {
-  connect() {
-    this.element.textContent = "Hello World!"
-  }
-}

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -2,9 +2,9 @@
   <% if @latest_rolls.compact.present? %>
     <%= form_with(model: Idea.new, class: "grid grid-cols-3 grid-rows-[auto,auto,minmax(150px,auto)] gap-12") do |form| %>
       <% @latest_rolls.each do |roll| %>
-        <div class="p-8 text-center bg-blue-500 text-white aspect-[1/1]">
+        <div>
           <%= turbo_stream_from dom_id(roll.side.die) %>
-          <div id="<%= dom_id(roll.side.die) %>" class="h-full flex justify-center items-center">
+          <div id="<%= dom_id(roll.side.die) %>" class="text-white">
             <%= render partial: "rolls/roll", locals: {roll: roll} %>
           </div>
         </div>

--- a/app/views/rolls/_roll.html.erb
+++ b/app/views/rolls/_roll.html.erb
@@ -1,5 +1,9 @@
-<%= tag.div id: dom_id(roll) do %>
-  <input type="hidden" autocomplete="off" value="<%= roll.id %>" name="idea[roll_ids][]">
-  <h2 class="text-xl lg:text-3xl font-normal"><%= roll.side.title %></h2>
-  <p class="mt-2 inline-block text-blue-100 font-bold text-xs px-2 py-0.5 bg-blue-400"><%= roll.side.die.shortcode %><%= roll.side.shortcode %></p>
+<%= tag.div id: dom_id(roll),
+  class: "aspect-[1/1] flex flex-wrap justify-center items-center p-8 text-center bg-blue-500 hidden",
+  data: {controller: "appear", transition_enter: "transition ease-in-out duration-700", transition_enter_start: "transform -rotate-180 text-blue-100/0", transition_enter_end: "transform rotate-0 text-blue-100/100", transition_leave_start: "transform rotate-0 text-blue-100/100", transition_leave_end: "transform rotate-180 text-blue-100/0"} do %>
+  <div>
+    <input type="hidden" autocomplete="off" value="<%= roll.id %>" name="idea[roll_ids][]">
+    <h2 class="w-full text-xl lg:text-3xl font-normal"><%= roll.side.title %></h2>
+    <p class="mt-2 inline-block font-bold text-xs px-2 py-0.5 bg-blue-400"><%= roll.side.die.shortcode %><%= roll.side.shortcode %></p>
+  </div>
 <% end %>

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -5,3 +5,4 @@ pin "@hotwired/turbo-rails", to: "turbo.min.js", preload: true
 pin "@hotwired/stimulus", to: "stimulus.min.js", preload: true
 pin "@hotwired/stimulus-loading", to: "stimulus-loading.js", preload: true
 pin_all_from "app/javascript/controllers", under: "controllers"
+pin "el-transition", to: "https://ga.jspm.io/npm:el-transition@0.0.7/index.js"


### PR DESCRIPTION
This PR makes sure that incoming rolls (e.g. via Turbo broadcasts) are animated. We do this using the [`el-transition`](https://github.com/mmccall10/el-transition) lib and a small Stimulus controller.

(This [guide](https://github.com/mmccall10/el-transition) helped quite a lot for implementing the feature)