### PR TITLE
fix: only render dice that have rolls

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -2,7 +2,8 @@ class PagesController < ApplicationController
   def home
     @latest_rolls = []
     Die.all.each do |die|
-      @latest_rolls << Roll.latest_for(die: die)
+      latest_roll = Roll.latest_for(die: die)
+      @latest_rolls << latest_roll unless latest_roll.blank?
     end
   end
 end

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,5 +1,5 @@
 <div class="mt-16 p-8 w-full justify-self-center self-top">
-  <% if @latest_rolls.compact.present? %>
+  <% if @latest_rolls.present? %>
     <%= form_with(model: Idea.new, class: "grid grid-cols-3 grid-rows-[auto,auto,minmax(150px,auto)] gap-12") do |form| %>
       <% @latest_rolls.each do |roll| %>
         <div>


### PR DESCRIPTION
Previously we had some nil's in the @latest_rolls. This caused the UI to crash because we tried accessing methods on nil's. This change only adds rolls to the @latest_rolls if a roll is found.