### PR TITLE
feat: generate idea on ArrowRight keydown

### DIFF
--- a/app/javascript/controllers/form_controller.js
+++ b/app/javascript/controllers/form_controller.js
@@ -1,0 +1,7 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  submitForm() {
+    this.element.requestSubmit();
+  }
+}

--- a/app/javascript/controllers/form_controller.js
+++ b/app/javascript/controllers/form_controller.js
@@ -1,7 +1,12 @@
 import { Controller } from "@hotwired/stimulus";
 
+/**
+ * Controller to enhance HTML form elements with additional behaviour.
+ * As of now we provide a submit method, that can be triggered e.g. through
+ * keyboard actions such as keyboard events, see https://stimulus.hotwired.dev/reference/actions
+ */
 export default class extends Controller {
-  submitForm() {
+  submit() {
     this.element.requestSubmit();
   }
 }

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,6 +1,6 @@
 <div class="mt-16 p-8 w-full justify-self-center self-top">
   <% if @latest_rolls.present? %>
-    <%= form_with(model: Idea.new, class: "grid grid-cols-3 grid-rows-[auto,auto,minmax(150px,auto)] gap-12", data: { controller: "form", action: "keydown.right@window->form#submitForm" }) do |form| %>
+    <%= form_with(model: Idea.new, class: "grid grid-cols-3 grid-rows-[auto,auto,minmax(150px,auto)] gap-12", data: { controller: "form", action: "keydown.right@window->form#submit" }) do |form| %>
       <% @latest_rolls.each do |roll| %>
         <div>
           <%= turbo_stream_from dom_id(roll.side.die) %>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,6 +1,6 @@
 <div class="mt-16 p-8 w-full justify-self-center self-top">
   <% if @latest_rolls.present? %>
-    <%= form_with(model: Idea.new, class: "grid grid-cols-3 grid-rows-[auto,auto,minmax(150px,auto)] gap-12") do |form| %>
+    <%= form_with(model: Idea.new, class: "grid grid-cols-3 grid-rows-[auto,auto,minmax(150px,auto)] gap-12", data: { controller: "form", action: "keydown.right@window->form#submitForm" }) do |form| %>
       <% @latest_rolls.each do |roll| %>
         <div>
           <%= turbo_stream_from dom_id(roll.side.die) %>
@@ -9,7 +9,6 @@
           </div>
         </div>
       <% end %>
-      <%= form.submit "Idee generieren", class: "col-span-3 w-full text-xl bg-magenta-500 font-bold text-white p-3 cursor-pointer disabled:bg-magenta-200 disabled:cursor-not-allowed" %>
       <%= tag.div class: "col-span-3" do %>
         <%= turbo_stream_from "idea-stream" %>
         <%= render partial: "ideas/idea", locals: { idea: nil } %>


### PR DESCRIPTION
This PR changes the submit interaction for the idea creation. Where it was previously a submit button, we've now removed the button, because the idea machine is gonna be handled solely through keyboard interactions.

We do this by adding a [Stimulus controller](https://stimulus.hotwired.dev/) that enables us to programmatically fire submit events on the form (in our case through a ArrowRight keydown).