### PR TITLE
feat: enable all arrows

### DIFF
--- a/.github/workflows/rails.yml
+++ b/.github/workflows/rails.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Run tests
         env:
           RAILS_ENV: test
-        run: bin/rails test:prepare test
+        run: bin/rails test:prepare test:all
 
   lint:
     runs-on: ubuntu-latest

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,6 +1,6 @@
 <div class="mt-16 p-8 w-full justify-self-center self-top">
   <% if @latest_rolls.present? %>
-    <%= form_with(model: Idea.new, class: "grid grid-cols-3 grid-rows-[auto,auto,minmax(150px,auto)] gap-12", data: { controller: "form", action: "keydown.right@window->form#submit" }) do |form| %>
+    <%= form_with(model: Idea.new, class: "grid grid-cols-3 grid-rows-[auto,auto,minmax(150px,auto)] gap-12", data: { controller: "form", action: "keydown.right@window->form#submit keydown.left@window->form#submit keydown.up@window->form#submit keydown.down@window->form#submit" }) do |form| %>
       <% @latest_rolls.each do |roll| %>
         <div>
           <%= turbo_stream_from dom_id(roll.side.die) %>

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,5 +1,5 @@
 require "test_helper"
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
-  driven_by :selenium, using: :chrome, screen_size: [1400, 1400]
+  driven_by :selenium, using: :headless_chrome, screen_size: [1400, 1400]
 end

--- a/test/system/operator_creates_idea_test.rb
+++ b/test/system/operator_creates_idea_test.rb
@@ -1,0 +1,53 @@
+require "application_system_test_case"
+
+class OperatorCreatesIdeaTest < ApplicationSystemTestCase
+  CREATED_IDEA_TEXT = "A beautiful, new idea"
+
+  test "creating an idea via keydown ArrowUp" do
+    stub_idea
+
+    visit "/"
+
+    send_keys(:up)
+
+    assert_text CREATED_IDEA_TEXT
+  end
+
+  test "creating an idea via keydown ArrowRight" do
+    stub_idea
+
+    visit "/"
+
+    send_keys(:right)
+
+    assert_text CREATED_IDEA_TEXT
+  end
+
+  test "creating an idea via keydown ArrowDown" do
+    stub_idea
+
+    visit "/"
+
+    send_keys(:down)
+
+    assert_text CREATED_IDEA_TEXT
+  end
+
+  test "creating an idea via keydown ArrowLeft" do
+    stub_idea
+
+    visit "/"
+
+    send_keys(:left)
+
+    assert_text CREATED_IDEA_TEXT
+  end
+
+  private
+
+  def stub_idea
+    stubbed_minimal_response_body = {choices: [{message: {content: CREATED_IDEA_TEXT}}]}
+    stub_request(:post, "https://api.openai.com/v1/chat/completions")
+      .to_return(status: 200, body: stubbed_minimal_response_body.to_json)
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,7 +10,7 @@ require_relative "../config/environment"
 require "rails/test_help"
 require "webmock/minitest"
 
-WebMock.disable_net_connect!(allow_localhost: true)
+WebMock.disable_net_connect!(allow_localhost: true, allow: "chromedriver.storage.googleapis.com")
 
 class ActiveSupport::TestCase
   # Run tests in parallel with specified workers


### PR DESCRIPTION
This PR enables all arrows for submitting the ideas form. We do this because we don't know yet which click device (and which arrows) will be available to our exhibit.