### PR TITLE
feat: timer for ideas form submit

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,6 +1,7 @@
 class PagesController < ApplicationController
   def home
     @latest_rolls = []
+    @timer = params[:timer]
     Die.all.each do |die|
       latest_roll = Roll.latest_for(die: die)
       @latest_rolls << latest_roll unless latest_roll.blank?

--- a/app/javascript/controllers/idea_form_controller.js
+++ b/app/javascript/controllers/idea_form_controller.js
@@ -6,10 +6,27 @@ import { Controller } from "@hotwired/stimulus";
  */
 export default class extends Controller {
   static targets = ["input"];
+  static values = { timer: { type: Number, default: -1 } };
 
-  inputTargetConnected(element) {
-    console.log("Connected");
-    console.log(element);
+  timerId() {
+    return null;
+  }
+
+  inputTargetConnected() {
+    if (this.timerId) {
+      clearTimeout(this.timerId);
+    }
+
+    const timerInMilliseconds = this.timerValue * 1000;
+
+    const isValidTimer =
+      timerInMilliseconds > 1000 || timerInMilliseconds < 10_000;
+
+    if (isValidTimer) {
+      this.timerId = setTimeout(() => {
+        this.submit();
+      }, timerInMilliseconds);
+    }
   }
 
   submit() {

--- a/app/javascript/controllers/idea_form_controller.js
+++ b/app/javascript/controllers/idea_form_controller.js
@@ -3,6 +3,7 @@ import { Controller } from "@hotwired/stimulus";
 /**
  * Controller that enhances the ideas form. When programmatically submitting the form,
  * we set a loading message. This is not an ideal implementation, but for now it's okay.
+ * We also let the form auto-submit when a URL param for a timer is present.
  */
 export default class extends Controller {
   static targets = ["input"];
@@ -20,7 +21,7 @@ export default class extends Controller {
     const timerInMilliseconds = this.timerValue * 1000;
 
     const isValidTimer =
-      timerInMilliseconds > 1000 || timerInMilliseconds < 10_000;
+      timerInMilliseconds > 1000 && timerInMilliseconds < 10_000;
 
     if (isValidTimer) {
       this.timerId = setTimeout(() => {

--- a/app/javascript/controllers/idea_form_controller.js
+++ b/app/javascript/controllers/idea_form_controller.js
@@ -5,6 +5,13 @@ import { Controller } from "@hotwired/stimulus";
  * we set a loading message. This is not an ideal implementation, but for now it's okay.
  */
 export default class extends Controller {
+  static targets = ["input"];
+
+  inputTargetConnected(element) {
+    console.log("Connected");
+    console.log(element);
+  }
+
   submit() {
     this.element.requestSubmit();
     this.showLoadingState();

--- a/app/models/roll.rb
+++ b/app/models/roll.rb
@@ -13,7 +13,7 @@ class Roll < ApplicationRecord
   private
 
   def update_latest_roll
-    broadcast_update_to(dom_id(side.die), target: dom_id(side.die), partial: "rolls/roll", locals: {roll: self})
+    broadcast_update_to(dom_id(side.die), target: dom_id(side.die), partial: "rolls/roll", locals: {roll: self, data: {idea_form_target: "input"}})
     broadcast_replace_to("idea-stream", target: "idea", partial: "ideas/idea_placeholder")
   end
 end

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,6 +1,6 @@
 <%= tag.div class: class_names("w-full max-w-screen-lg mx-auto", "px-8 pt-0", "flex items-center") do %>
   <% if @latest_rolls.present? %>
-    <%= form_with(model: Idea.new, class: class_names("w-full h-full", "grid grid-cols-3 gap-12"), data: { controller: "idea-form", action: "keydown.right@window->idea-form#submit keydown.left@window->idea-form#submit keydown.up@window->idea-form#submit keydown.down@window->idea-form#submit" }) do |form| %>
+    <%= form_with(model: Idea.new, class: class_names("w-full h-full", "grid grid-cols-3 gap-12"), data: { controller: "idea-form", idea_form_timer_value: @timer, action: "keydown.right@window->idea-form#submit keydown.left@window->idea-form#submit keydown.up@window->idea-form#submit keydown.down@window->idea-form#submit" }) do |form| %>
       <% @latest_rolls.each do |roll| %>
         <%= tag.div class: class_names("w-full h-full", "flex items-center") do %>
           <%= turbo_stream_from dom_id(roll.side.die) %>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -5,7 +5,7 @@
         <%= tag.div class: class_names("w-full h-full", "flex items-center") do %>
           <%= turbo_stream_from dom_id(roll.side.die) %>
           <%= tag.div id: dom_id(roll.side.die), class: "w-full text-gray-900" do %>
-            <%= render partial: "rolls/roll", locals: {roll: roll} %>
+            <%= render partial: "rolls/roll", locals: {roll: roll, data: {idea_form_target: "input"}} %>
           <% end %>
         <% end %>
       <% end %>

--- a/app/views/rolls/_roll.html.erb
+++ b/app/views/rolls/_roll.html.erb
@@ -1,4 +1,4 @@
-<%= render(DieComponent.new(theme: roll.side.die.title, id: dom_id(roll))) do |component| %>
+<%= render(DieComponent.new(theme: roll.side.die.title, id: dom_id(roll), data: { **local_assigns[:data] || {} } )) do |component| %>
   <% component.with_hidden_input_field do %>
     <input type="hidden" autocomplete="off" value="<%= roll.id %>" name="idea[roll_ids][]">
   <% end %>

--- a/test/system/browser_auto_submits_idea_form.rb
+++ b/test/system/browser_auto_submits_idea_form.rb
@@ -1,0 +1,29 @@
+require "application_system_test_case"
+
+class BrowserAutoSubmitsIdeaTest < ApplicationSystemTestCase
+  CREATED_IDEA_TEXT = "A beautiful, new idea"
+
+  test "auto-submits idea form after 3s timeout" do
+    stub_idea
+
+    visit "/?timer=3"
+
+    assert_text CREATED_IDEA_TEXT, wait: 10
+  end
+
+  test "does not auto-submit idea form with invalid timer" do
+    stub_idea
+
+    visit "/?timer=x"
+
+    assert_no_text CREATED_IDEA_TEXT, wait: 10
+  end
+
+  private
+
+  def stub_idea
+    stubbed_minimal_response_body = {choices: [{message: {content: CREATED_IDEA_TEXT}}]}
+    stub_request(:post, "https://api.openai.com/v1/chat/completions")
+      .to_return(status: 200, body: stubbed_minimal_response_body.to_json)
+  end
+end


### PR DESCRIPTION
This PR enables us to auto-submit the ideas form after a certain timeout. The timeout can be provided in the URL params, like so: `http://localhost:3000?timer=5` (value is in seconds). We currently restrict this value to be **between 1 and 10** and if it isn't, the auto-submit functionality is not triggered. Also, if there is no such URL param present, the auto-submit isn't invoked either.

> Note that an initial auto-submit is triggered when first opening the URL with the URL param.