### PR TITLE
feat: better loading indication

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -25,5 +25,5 @@
 }
 
 .turbo-progress-bar {
-  @apply bg-pink h-2;
+  @apply hidden;
 }

--- a/app/components/frame_component.html.erb
+++ b/app/components/frame_component.html.erb
@@ -3,7 +3,7 @@
   <%= tag.div class: class_names("absolute top-0 right-0", "w-8 h-8", "border-t-4 border-r-4 border-gray-900", "-translate-y-0.5 translate-x-0.5") %>
   <%= tag.div class: class_names("absolute bottom-0 right-0", "w-8 h-8", "border-b-4 border-r-4 border-gray-900", "translate-y-0.5 translate-x-0.5") %>
   <%= tag.div class: class_names("absolute bottom-0 left-0", "w-8 h-8", "border-b-4 border-l-4 border-gray-900", "translate-y-0.5 -translate-x-0.5") %>
-  <%= tag.div class: class_names("w-full h-full flex items-center") do %>
+  <%= tag.div class: class_names("w-full h-full flex items-center justify-center") do %>
     <%= content %>
   <% end %>
 <% end %>

--- a/app/components/spinner_component.html.erb
+++ b/app/components/spinner_component.html.erb
@@ -1,0 +1,6 @@
+<%= tag.svg **@args do %>
+  <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+  <path class="opacity-100" fill="currentColor"
+    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z">
+  </path>
+<% end %>

--- a/app/components/spinner_component.rb
+++ b/app/components/spinner_component.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class SpinnerComponent < ViewComponent::Base
+  def initialize(**args)
+    @args = args
+    @args[:class] = class_names(@args[:class], "text-gray-900", "-ml-1 mr-3 h-6 w-6", "animate-spin")
+    @args["viewBox"] = "0 0 24 24"
+    @args[:fill] = "none"
+    @args[:xmlns] = "http://www.w3.org/2000/svg"
+  end
+end

--- a/app/javascript/controllers/idea_form_controller.js
+++ b/app/javascript/controllers/idea_form_controller.js
@@ -38,11 +38,14 @@ export default class extends Controller {
   showLoadingState() {
     const ideaPlaceholderWrapper = document.getElementById("idea");
 
-    ideaPlaceholderWrapper.classList.add("w-full");
-    ideaPlaceholderWrapper.classList.add("text-gray-400");
     ideaPlaceholderWrapper.classList.add("text-center");
+    ideaPlaceholderWrapper.classList.add("text-gray-900");
 
     const placeholderParagraph = idea.querySelector("p");
     placeholderParagraph.textContent = "Idee wird generiert ...";
+
+    const spinner = document.getElementById("spinner");
+    spinner.classList.remove("hidden");
+    spinner.classList.add("block");
   }
 }

--- a/app/views/ideas/_idea_placeholder.html.erb
+++ b/app/views/ideas/_idea_placeholder.html.erb
@@ -1,1 +1,2 @@
-<%= render partial: "ideas/idea", locals: { idea: Idea.new(description: "Eine Idee für Berlin"), class: "w-full text-gray-400 text-center" } %>
+<%= render(SpinnerComponent.new(id: "spinner", class: "hidden")) %>
+<%= render partial: "ideas/idea", locals: { idea: Idea.new(description: "Eine Idee für Berlin"), class: "text-gray-400 text-center" } %>

--- a/app/views/ideas/create.turbo_stream.erb
+++ b/app/views/ideas/create.turbo_stream.erb
@@ -1,1 +1,2 @@
 <%= turbo_stream.replace "idea", @idea %>
+<%= turbo_stream.replace "spinner", SpinnerComponent.new(id: "spinner", class: "hidden") %>


### PR DESCRIPTION
This PR improves the loading indicator (that was not super visible on our exhibit screen).

![Screen Shot 2023-06-27 at 11 56 43](https://github.com/technologiestiftung/idea-machine/assets/15640196/820c04a7-d69a-422e-a03f-d1b4da22daeb)

The following changes:

- we add a loading spinner in front of "Idee wird generiert ..."
- "Idee wird generiert ..." now has a dark grey text instead of medium grey
- we remove the progress bar at the top of the screen because we indicate loading via the spinner now

**Important**: This PR is a hotfix and not necessarily the cleanest implementation. Let's merge this for now and take onb the refactor a bit later.