### PR TITLE
refactor: extract text generation service

### DIFF
--- a/app/services/idea_generation_service.rb
+++ b/app/services/idea_generation_service.rb
@@ -15,16 +15,6 @@ class IdeaGenerationService
       in einer Zeile beschrieben wird. Themenfeld: #{topic}, Zielgruppe #{focus_group} Medium: #{medium}. Ein bisschen futuristisch und witzig kann die die Antwort auch sein. Die Antwort soll so formatiert sein: "Titel": Beschreibung
     PROMPT
 
-    openai_client = OpenAI::Client.new(access_token: Rails.application.credentials.openai_token)
-
-    response = openai_client.chat(
-      parameters: {
-        model: "gpt-3.5-turbo",
-        messages: [{role: "user", content: prompt}],
-        temperature: 0.7
-      }
-    )
-
-    response.dig("choices", 0, "message", "content")
+    TextGenerationService.new(prompt).call
   end
 end

--- a/app/services/text_generation_service.rb
+++ b/app/services/text_generation_service.rb
@@ -1,0 +1,19 @@
+class TextGenerationService
+  def initialize(prompt)
+    @prompt = prompt
+  end
+
+  def call
+    openai_client = OpenAI::Client.new(access_token: Rails.application.credentials.openai_token)
+
+    response = openai_client.chat(
+      parameters: {
+        model: "gpt-3.5-turbo",
+        messages: [{role: "user", content: @prompt}],
+        temperature: 0.7
+      }
+    )
+
+    response.dig("choices", 0, "message", "content")
+  end
+end

--- a/test/services/text_generation_service_test.rb
+++ b/test/services/text_generation_service_test.rb
@@ -1,0 +1,38 @@
+require "test_helper"
+
+class TextGenerationServiceTest < ActiveSupport::TestCase
+  RETURNED_TEXT = "lorem ipsum"
+
+  test "generates text" do
+    stub_successful_openai_response
+
+    text = TextGenerationService.new("gimme text").call
+    assert_equal text, RETURNED_TEXT
+  end
+
+  test "returns nil when OpenAI API sends error" do
+    stub_unsuccessful_openai_response
+
+    text = TextGenerationService.new("gimme text").call
+
+    assert_nil text
+  end
+
+  private
+
+  def stub_successful_openai_response
+    stubbed_response_body = {choices: [{message: {content: RETURNED_TEXT}}]}
+    stub_request(:post, "https://api.openai.com/v1/chat/completions")
+      .to_return(status: 200, body: stubbed_response_body.to_json)
+  end
+
+  def stub_unsuccessful_openai_response
+    stubbed_response_body = {error:
+      {message: "Incorrect API key provided: *********. You can find your API key at https://platform.openai.com/account/api-keys.",
+       type: "invalid_request_error",
+       param: nil,
+       code: "invalid_api_key"}}
+    stub_request(:post, "https://api.openai.com/v1/chat/completions")
+      .to_return(status: 401, body: stubbed_response_body.to_json)
+  end
+end


### PR DESCRIPTION
This PR separates text generation from idea generation because the previous `IdeaGenerationService` was concerned with too many different things. Now we have a cohesive `IdeaGenerationService` which handles processing the rolled sides and formulating our idea prompt. That prompt is then sent to a more generic `TextGenerationService` which handles the Chat-GPT logic.