### PR TITLE
chore: update fly.io deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax = docker/dockerfile:1
 
 # Make sure RUBY_VERSION matches the Ruby version in .ruby-version and Gemfile
-ARG RUBY_VERSION=3.2.0
+ARG RUBY_VERSION=3.2.2
 FROM ruby:$RUBY_VERSION-slim as base
 
 LABEL fly_launch_runtime="rails"

--- a/fly.toml
+++ b/fly.toml
@@ -1,4 +1,4 @@
-# fly.toml app configuration file generated for idea-machine on 2023-06-15T15:09:20+02:00
+# fly.toml app configuration file generated for idea-machine on 2023-08-02T14:34:00+02:00
 #
 # See https://fly.io/docs/reference/configuration/ for information about how to use this file.
 #
@@ -6,6 +6,8 @@
 app = "idea-machine"
 console_command = "/rails/bin/rails console"
 primary_region = "ams"
+
+[build]
 
 [[mounts]]
 destination = "/mnt/idea_machine_production"


### PR DESCRIPTION
This PR updates the project so that we use a Fly.io deployment. This means we remove the documentation for the Raspberry Pi setup as it is no longer needed.