### PR TITLE
feat: create initial roll on side creation

### DIFF
--- a/app/models/side.rb
+++ b/app/models/side.rb
@@ -3,10 +3,17 @@ class Side < ApplicationRecord
   after_initialize do |side|
     side.variations ||= [side.title] if side.variations.blank?
   end
+  after_commit :roll_side, on: [:create], if: proc { |side| side.die.rolls.empty? }
 
   belongs_to :die
   has_many :rolls, dependent: :destroy
 
   validates :title, :variations, presence: true
   validates :shortcode, presence: true, uniqueness: {scope: :die_id}
+
+  private
+
+  def roll_side
+    Roll.create side: self
+  end
 end

--- a/test/models/side_test.rb
+++ b/test/models/side_test.rb
@@ -12,4 +12,20 @@ class SideTest < ActiveSupport::TestCase
     assert side.errors[:title].present?
     assert side.errors[:shortcode].present?
   end
+
+  test "creates roll if side is first of die" do
+    die = Die.create(title: 1, shortcode: "X")
+    side = Side.create(die: die, title: "first", shortcode: "1")
+
+    assert_equal side.rolls.size, 1
+  end
+
+  test "does not create roll if die already has rolls from another side" do
+    die = Die.create(title: 1, shortcode: "X")
+    Side.create(die: die, title: "first", shortcode: "1")
+
+    second_side = Side.create(die: die, title: "second", shortcode: "2")
+
+    assert second_side.rolls.empty?
+  end
 end


### PR DESCRIPTION
This mostly makes sure that we have @latest_rolls for each die, so that idea creation could be triggered immediately.