### PR TITLE
feat: shutdown raspi via Rails app

### DIFF
--- a/app/controllers/raspi/shutdowns_controller.rb
+++ b/app/controllers/raspi/shutdowns_controller.rb
@@ -1,0 +1,4 @@
+class Raspi::ShutdownsController < ApplicationController
+  def show
+  end
+end

--- a/app/javascript/controllers/localhost_post_controller.js
+++ b/app/javascript/controllers/localhost_post_controller.js
@@ -15,7 +15,7 @@ export default class extends Controller {
   };
 
   connect() {
-    this.hasBodyValue && this.sendRequest();
+    this.sendRequest();
   }
 
   sendRequest() {
@@ -25,7 +25,7 @@ export default class extends Controller {
         "Content-Type": "application/json",
         Authorization: `Bearer ${this.tokenValue}`,
       },
-      body: JSON.stringify(this.bodyValue),
+      body: this.hasBodyValue ? JSON.stringify(this.bodyValue) : null,
     });
   }
 

--- a/app/views/raspi/shutdowns/show.html.erb
+++ b/app/views/raspi/shutdowns/show.html.erb
@@ -1,0 +1,6 @@
+<%= tag.div class: "flex justify-center items-center" do %>
+  <%= tag.div data: {controller: "localhost-post", localhost_post_path_value: "/shutdown"}, class: "text-center" do %>
+    <%= tag.h1 "Raspberry Pi wird heruntergefahren", class: "font-bold text-5xl" %>
+    <%= tag.p "Dies kann bis zu einer Minute dauern", class: "text-3xl" %>
+  <% end %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,4 +8,8 @@ Rails.application.routes.draw do
       resources :rolls, only: [:create]
     end
   end
+
+  namespace :raspi do
+    get "shutdown", to: "shutdowns#show"
+  end
 end

--- a/test/controllers/raspi/shutdowns_controller_test.rb
+++ b/test/controllers/raspi/shutdowns_controller_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class Raspi::ShutdownsControllerTest < ActionDispatch::IntegrationTest
+  test "shows shutdown page" do
+    get raspi_shutdown_url
+    assert_response :success
+  end
+end


### PR DESCRIPTION
This PR makes sure that this Rails app can call the local server on the Raspi. By POSTing to `/shutdown` on the [local Node server](https://github.com/technologiestiftung/idea-machine-printing-server) we shutdown the Raspi safely.

**Note that the `/shutdown` route is not yet implemented on the Node server!**