### PR TITLE
feat: broadcast Raspi shutdown to clients

### DIFF
--- a/app/controllers/raspi/shutdowns_controller.rb
+++ b/app/controllers/raspi/shutdowns_controller.rb
@@ -1,4 +1,5 @@
 class Raspi::ShutdownsController < ApplicationController
   def show
+    Raspi::Shutdown.new
   end
 end

--- a/app/models/raspi/shutdown.rb
+++ b/app/models/raspi/shutdown.rb
@@ -1,0 +1,15 @@
+class Raspi::Shutdown
+  extend ActiveModel::Callbacks
+
+  define_model_callbacks :initialize
+
+  def initialize
+    run_callbacks :initialize
+  end
+
+  after_initialize :broadcast_shutdown
+
+  def broadcast_shutdown
+    Turbo::StreamsChannel.broadcast_replace_to :shutdowns, target: "shutdowns-listener", partial: "raspi/shutdowns/trigger"
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,5 +16,6 @@
     <main class="container mx-auto h-full max-w-screen-2xl grid grid-cols-1 grid-rows-[5fr,7fr] gap-y-12">
       <%= yield %>
     </main>
+    <%= render "shared/shutdowns_stream" %>
   </body>
 </html>

--- a/app/views/raspi/shutdowns/_trigger.html.erb
+++ b/app/views/raspi/shutdowns/_trigger.html.erb
@@ -1,0 +1,1 @@
+<%= tag.div data: {controller: "localhost-post", localhost_post_path_value: "/shutdown", localhost_post_token_value: Rails.application.credentials.raspi_server.publicly_visible_token}, class: "text-center" %>

--- a/app/views/raspi/shutdowns/show.html.erb
+++ b/app/views/raspi/shutdowns/show.html.erb
@@ -1,6 +1,6 @@
 <%= tag.div class: "flex justify-center items-center" do %>
-  <%= tag.div data: {controller: "localhost-post", localhost_post_path_value: "/shutdown", localhost_post_token_value: Rails.application.credentials.raspi_server.publicly_visible_token}, class: "text-center" do %>
+  <%= tag.div class: "text-center" do %>
     <%= tag.h1 "Raspberry Pi wird heruntergefahren", class: "font-bold text-5xl" %>
-    <%= tag.p "Dies kann bis zu einer Minute dauern", class: "text-3xl" %>
+    <%= tag.p "Bitte warte 1 Minute bis du die Stromzufuhr trennst.", class: "text-3xl" %>
   <% end %>
 <% end %>

--- a/app/views/shared/_shutdowns_stream.html.erb
+++ b/app/views/shared/_shutdowns_stream.html.erb
@@ -1,0 +1,4 @@
+<%= tag.div class: "fixed top-0 left-0 invisible" do %>
+  <%= turbo_stream_from "shutdowns" %>
+  <%= tag.div id: "shutdowns-listener" %>
+<% end %>


### PR DESCRIPTION
This is a weird one.

We want to be able to remotely control the graceful shutdown of the Raspberry Pi. The idea is to e.g. pick your phone, open the `/raspi/shutdown` route and have the Raspberry Pi shut down correctly. This is achieved with this PR: 

A websocket sends a message to all connected clients (including the browser on the Raspi). Because the Node server on the Raspi [has implemented](https://github.com/technologiestiftung/idea-machine-printing-server/pull/2) a `/shutdown` route that is requested with the websocket message, we are able to shutdown the Raspi gracefully.

**Important**: This is hacky. We do this because of time and resource limitations: This Rails app already exists and functions and so does the Node server on the Raspi. Ideally we would not need all of this back and forth and just implement everything necessary on the Raspi (e.g. by repurposing the Node server to handle all functionality). We want to investigate that in the near future.